### PR TITLE
add postgres uri configuration on gateway

### DIFF
--- a/chart/gateway/templates/secret-configs.yaml
+++ b/chart/gateway/templates/secret-configs.yaml
@@ -5,6 +5,9 @@ metadata:
 type: Opaque
 stringData:
   XTDB_ADDRESS: "{{ .Values.config.XTDB_ADDRESS | default "http://127.0.0.1:3001" }}"
+  {{- with .Values.xtdbConfig }}
+  POSTGRES_DB_URI: "postgresql://{{ .PG_USER }}:{{ .PG_PASSWORD }}@{{ .PG_HOST }}:{{ .PG_PORT }}/{{ .PG_DB }}"
+  {{- end }}
   API_URL: "{{ required "config.API_URL is required" .Values.config.API_URL }}"
   GIN_MODE: "{{ .Values.config.GIN_MODE | default "release" }}"
   LOG_ENCODING: "{{ .Values.config.LOG_ENCODING | default "json" }}"


### PR DESCRIPTION
Add `POSTGRES_DB_URI` env to expose credentials to the gateway process runtime