### PR TITLE
Add slack env into secrets

### DIFF
--- a/chart/gateway/templates/secret-configs.yaml
+++ b/chart/gateway/templates/secret-configs.yaml
@@ -44,6 +44,8 @@ stringData:
   SMTP_PORT: "{{ .Values.config.SMTP_PORT }}"
   SMTP_USER: "{{ .Values.config.SMTP_USER }}"
   SMTP_PASS: "{{ .Values.config.SMTP_PASS }}"
+  SLACK_CLIENT_ID: "{{ .Values.config.SLACK_CLIENT_ID }}"
+  SLACK_CLIENT_SECRET: "{{ .Values.config.SLACK_CLIENT_SECRET }}"
 ---
 apiVersion: v1
 kind: Secret

--- a/chart/gateway/values.yaml
+++ b/chart/gateway/values.yaml
@@ -18,7 +18,6 @@ image:
     pullPolicy: Always
     tag: latest
 
-
 agentConfig:
   # enables a sidecar agent to the gateway.
   # it must be able to auto register itself or connect it using a grpc_url and token
@@ -52,9 +51,11 @@ config:
   # SMTP_PORT: ''
   # SMTP_USER: ''
   # SMTP_PASS: ''
+  # SLACK_CLIENT_ID: ''
+  # SLACK_CLIENT_SECRET: ''
   notification: {}
-    # slackBotToken: ''
-    # bridgeUrl: ''
+  #   slackBotToken: ''
+  #   bridgeUrl: ''
 
 # hoop gateway configuration. Please refer to https://hoop.dev/docs/configuring/gateway
 xtdbConfig:
@@ -67,7 +68,7 @@ xtdbConfig:
   ROCKS_DB_CACHE_SIZE: '536870912' # 512MB
   ROCKS_DB_DIR: '/opt/hoop/sessions/rocksdb'
   # JVM_OPTS: ''
-  
+
 ingressApi:
   # -- Enables Ingress
   enabled: false


### PR DESCRIPTION
This PR contains the environment variables necessary to run the Slack app on the API.

You can find more information here:
https://www.notion.so/hoopdotdev/Slack-app-credentials-011b0aee54134a79b001391db3a25c81?pvs=4